### PR TITLE
Use correct homepage url in gemspec

### DIFF
--- a/jekyll-bootflat.gemspec
+++ b/jekyll-bootflat.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["stefan.haslinger@panoptikum.io"]
 
   spec.summary       = %q{Twitter Bootstrap + Bootflat + Fontawesome = jekyll-bootflat theme}
-  spec.homepage      = "http://github.com/jekyll-octopod/jekyll-bootflat."
+  spec.homepage      = "http://github.com/jekyll-octopod/jekyll-bootflat"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|_layouts|_includes|_sass|LICENSE|README|index|screenshot)}i) }


### PR DESCRIPTION
On https://rubygems.org/gems/jekyll-bootflat link to homepage does not work because of a typo in the gemspec file.